### PR TITLE
feat(golang): downgrade version to 16 to avoid golang.org/issue/25192

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17.13-alpine3.16 as builder
+FROM golang:1.16.15-alpine3.15 as builder
 
 ARG GIT_TAG_NAME
 ARG LD_FLAGS="-s -w -X github.com/4nth0/golem/pkg/version.Version=$GIT_TAG_NAME"


### PR DESCRIPTION
Golang version 1.17 introduces a change in the http lib, we should downgrade to 1.16 or change the codebase

```
2022/10/04 15:40:18 http: URL query contains semicolon, which is no longer a supported separator; parts of the query may be stripped when parsed; see golang.org/issue/25192
```